### PR TITLE
Added directory creation in macOS install script to make it working.

### DIFF
--- a/install-macOS.sh
+++ b/install-macOS.sh
@@ -3,16 +3,14 @@
 # macOS :
 # syncs repo's files to default macOS folder locations for reason codecs
 ## NOT TESTED YET
-echo '\n';
-echo '---COPYING--------------------------+++- ';
-echo '\n';
+echo 'COPYING...';
 
+mkdir -p ~/Library/Application\ Support/Propellerhead\ Software/Remote/Codecs/Lua\ Codecs/Akai/
 cp ./Remote/Codecs/Lua\ Codecs/Akai/*.* ~/Library/Application\ Support/Propellerhead\ Software/Remote/Codecs/Lua\ Codecs/Akai/;
 echo 'Lua Codecs copied.';
-echo '\n';
 
+mkdir -p ~/Library/Application\ Support/Propellerhead\ Software/Remote/Maps/Akai/
 cp ./Remote/Maps/Akai/*.* ~/Library/Application\ Support/Propellerhead\ Software/Remote/Maps/Akai/;
 echo 'Remote Maps copied.';
-echo '\n';
 
-echo '---COMPLETE-------------------------XXX-';
+echo '⇨ COMPLETE';


### PR DESCRIPTION
Hi, your MacOS install script did not work because of missing directories under `~/Library/Application\ Support/Propellerhead\ Software/Remote/`. I have fixed this. Thanks for the nice work though.